### PR TITLE
Add OpenGL Support through cmake parameters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -113,6 +113,7 @@
         "*.ipp": "cpp",
         "mixinvector": "cpp",
         "fast_back_stack": "cpp",
-        "qgraphicspixmapitem": "cpp"
+        "qgraphicspixmapitem": "cpp",
+        "qopenglwidget": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,14 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
-find_package(Qt6 COMPONENTS OpenGL REQUIRED)
-find_package(Qt6 COMPONENTS OpenGLWidgets REQUIRED)
+
+option(USE_OPENGL "Enable OpenGL support" OFF)
+
+if(USE_OPENGL)
+    add_definitions(-DUSE_OPENGL)
+    find_package(Qt6 COMPONENTS OpenGL REQUIRED)
+    find_package(Qt6 COMPONENTS OpenGLWidgets REQUIRED)
+endif()
 
 add_executable(pcb_tracer
 	main.cpp
@@ -74,6 +80,10 @@ qt_add_resources(pcb_tracer "RESOURCES"
     FILES resources.qrc
 )
 
-target_link_libraries(pcb_tracer PRIVATE Qt6::Widgets Qt6::OpenGLWidgets)
+target_link_libraries(pcb_tracer PRIVATE Qt6::Widgets)
+
+if(USE_OPENGL)
+    target_link_libraries(pcb_tracer PRIVATE Qt6::OpenGLWidgets)
+endif()
 
 install(TARGETS pcb_tracer DESTINATION bin)

--- a/ZoomableGraphicsView.cpp
+++ b/ZoomableGraphicsView.cpp
@@ -2,19 +2,21 @@
 #include <QScrollBar>
 #include <QTransform>
 #include <QDebug>
-//#include <QOpenGLWidget>
-
+#ifdef USE_OPENGL
+#include <QOpenGLWidget>
+#endif
 ZoomableGraphicsView::ZoomableGraphicsView(QWidget* parent)
     : QGraphicsView(parent)
 {
-  /*
+    #ifdef USE_OPENGL
     QOpenGLWidget *glWidget = new QOpenGLWidget(this);
     setViewport(glWidget);
 
     QSurfaceFormat format;
     format.setSamples(16);  // You can adjust this value (2, 4, 8, 16) for quality vs performance
     glWidget->setFormat(format);
- */
+    #endif
+ 
     // Set rendering hints for better performance
     setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     setTransformationAnchor(QGraphicsView::AnchorUnderMouse);

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Use the `pcb-tracer-git` package from the AUR.
    mkdir build
    cd build
    ```
-5. Run CMake and compile:
+5. Run CMake and compile. You can pass `-DUSE_OPENGL=ON` to cmake to enable OpenGL support. OpenGL support is broken on Wayland yet, so beware.
    ```
    cmake ..
    make -j$(nproc)


### PR DESCRIPTION
Enables OpenGL support for rendering, which was commented before.

It allows to pass -DUSE_OPENGL=ON to cmake to enable OpenGL support. 

OpenGL support is broken on Wayland yet, so beware.